### PR TITLE
Issue with reopening Websocket after Idle 10m

### DIFF
--- a/UI/src/app/services/websocket.service.ts
+++ b/UI/src/app/services/websocket.service.ts
@@ -29,9 +29,6 @@ export class WebsocketService {
       this.ws.onerror = event => observer.error(event);
       this.ws.onclose = event => {
         console.debug("Websocket connection closed");
-        closeSubscriber.next();
-        closeSubscriber.complete();
-        observer.complete();
       };
 
       this.ws.onopen = event => {


### PR DESCRIPTION
There is no need for these lines as they also prevent the Observable from subscribing again which means the websocket is reopened but the frontend does not process it no more, there might be a better way of doing , I am no Angular expert, but removing these lines worked fine in my deployment here

https://eu-west-3-amer-demo.auth.eu-west-3.amazoncognito.com/login?client_id=3uouf490c5u4mfej54igv25am9&response_type=token&redirect_uri=https://d17sdmhwxn0gs2.cloudfront.net/callback

    closeSubscriber.next();
    closeSubscriber.complete();
    observer.complete();