### PR TITLE
Issue with reopening Websocket after Idle 10m

### DIFF
--- a/UI/src/app/services/websocket.service.ts
+++ b/UI/src/app/services/websocket.service.ts
@@ -31,7 +31,6 @@ export class WebsocketService {
         console.debug("Websocket connection closed");
         closeSubscriber.next();
         closeSubscriber.complete();
-        observer.complete();
       };
 
       this.ws.onopen = event => {


### PR DESCRIPTION
*#31*

There is non need for this line in websocket.service.ts as it also prevent the Observable from subscribing again which means the websocket is reopened but the frontend does not process it no more, there might be a better way of doing this but removing this line worked fine,
observer.complete();


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
